### PR TITLE
Replaced sed with perl

### DIFF
--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -138,7 +138,7 @@ main () {
               extension="${eachFile##*.}"
               what="${filename}\.${extension}"
               withwhat="${filename}\.${stripTag}\.${extension}"
-              sed -i -e "s/${what}/${withwhat}/g" "${eachMd}"
+              perl -pi -e "s/${what}/${withwhat}/g" "${eachMd}"
             done <<< "${files}"
         done
       body+="[Languages.${stripTag}]\nweight = ${tagsCount}\n"


### PR DESCRIPTION
Replaced sed with perl to prevent diffent behaviour of sed on BSD and Linux;