### PR TITLE
Refactor gulp tasks and add dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@
 const gulp = require('gulp');
 const gutil = require('gulp-util');
 
-// node filesystem 
+// node filesystem
 const fs = require('fs');
 
 // plugins - site
@@ -17,85 +17,85 @@ const uglify = require('gulp-uglify');
 const minify = require('gulp-minify');
 const shell = require('gulp-shell');
 
+// hugo-gulp-template
+const imagemin = require('gulp-imagemin');
+const size = require('gulp-size');
+const browserSync = require('browser-sync');
+const reload = browserSync.reload;
+
+
+// =================================================================
+// Paths
+// =================================================================
+
 var SLATE_PATH = "./themes/docuapi/static/slate/";
 
+var imageInput = './content/images/**/*';
+var imageOutput = './content/test-images';
+
+var sassScreen = 'stylesheets/screen.css.scss';
+var sassPrint = 'stylesheets/print.css.scss';
+
+var jsAllsearch = [
+      SLATE_PATH+"javascripts/lib/_energize.js",
+      SLATE_PATH+"javascripts/lib/_jquery.js",
+      SLATE_PATH+"javascripts/lib/_lunr.js",
+      SLATE_PATH+"javascripts/lib/_jquery.highlight.js",
+      SLATE_PATH+"javascripts/lib/_jquery_ui.js",
+      SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
+      SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
+      SLATE_PATH+"javascripts/app/_lang.js",
+      SLATE_PATH+"javascripts/app/_search.js",
+      SLATE_PATH+"javascripts/app/_toc.js",
+      SLATE_PATH+"javascripts/app/_custom.js"
+];
+
+var jsNoAllsearch = [
+      SLATE_PATH+"javascripts/lib/_energize.js",
+      SLATE_PATH+"javascripts/lib/_jquery.js",
+      SLATE_PATH+"javascripts/lib/_jquery_ui.js",
+      SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
+      SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
+      SLATE_PATH+"javascripts/app/_lang.js",
+      SLATE_PATH+"javascripts/app/_toc.js",
+      SLATE_PATH+"javascripts/app/_custom.js"
+];
+
+var jsOutput = SLATE_PATH+'javascripts';
+
+var assetsPath = [
+      SLATE_PATH+'stylesheets/**/*.scss',
+      SLATE_PATH+'javascripts/**/*.js'
+      ];
+
+var sassAll = SLATE_PATH+'stylesheets/**/*.scss';
+var jsAll = SLATE_PATH+'javascripts/**/*.js';
+
 // =================================================================
-// css build tasks
+// Serve - BrowserSync
 // =================================================================
 
-gulp.task("css:build:screen", function() {
-  return gulp.src(SLATE_PATH+"stylesheets/screen.css.scss")
-          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
-          .pipe(cleancss())
-          .pipe(prefixer({
-              browsers: ["last 2 versions"],
-              cascade: true, // prettify browser prefixes
-              remove: true // remove un-needed prefixes
-          }))
-          .pipe(concat('screen.min.css'))
-          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
+gulp.task('preview', function(cb) {
+  return runSeq(['css:build','js:build:all'],'hugo:all',cb);
 });
 
-
-gulp.task("css:build:print", function() {
-  return gulp.src(SLATE_PATH+"stylesheets/print.css.scss")
-          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
-          .pipe(cleancss())
-          .pipe(prefixer({
-              browsers: ["last 2 versions"],
-              cascade: true, // prettify browser prefixes
-              remove: true // remove un-needed prefixes
-          }))
-          .pipe(concat('print.min.css'))
-          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
+gulp.task('default', ['preview'], function() {
+  browserSync.init({
+    server: {
+      baseDir: './public/'
+    },
+    open: false
+  });
+  gulp.watch(jsAll, ['reload:js']);
+  gulp.watch(sassAll, ['reload:sass']);
+  gulp.watch('./content/**/*.md', ['reload:md']);
 });
 
+gulp.task('reload:js', ['preview'], reload);
 
-gulp.task('css:build', ['css:build:screen', 'css:build:print'], function() {
-  return;
-});
+gulp.task('reload:sass', ['preview'], reload);
 
-
-// =================================================================
-// js build tasks
-// =================================================================
-
-gulp.task("js:build:all", function(){
-  return gulp.src([SLATE_PATH+"javascripts/lib/_energize.js",
-          SLATE_PATH+"javascripts/lib/_jquery.js",
-          SLATE_PATH+"javascripts/lib/_lunr.js",
-          SLATE_PATH+"javascripts/lib/_jquery.highlight.js",
-          SLATE_PATH+"javascripts/lib/_jquery_ui.js",
-          SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
-          SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
-          SLATE_PATH+"javascripts/app/_lang.js",
-          SLATE_PATH+"javascripts/app/_search.js",
-          SLATE_PATH+"javascripts/app/_toc.js",
-          SLATE_PATH+"javascripts/app/_custom.js"])
-          .pipe(concat('all.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-
-gulp.task("js:build:all_nosearch", function(){
-  return gulp.src([SLATE_PATH+"javascripts/lib/_energize.js",
-          SLATE_PATH+"javascripts/lib/_jquery.js",
-          SLATE_PATH+"javascripts/lib/_jquery_ui.js",
-          SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
-          SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
-          SLATE_PATH+"javascripts/app/_lang.js",
-          SLATE_PATH+"javascripts/app/_toc.js",
-          SLATE_PATH+"javascripts/app/_custom.js"])
-          .pipe(concat('all_nosearch.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-gulp.task('js:build', ['js:build:all','js:build:all_nosearch'], function() {
-  return;
-});
-
+gulp.task('reload:md', ['preview'], reload);
 
 // =================================================================
 // hugo tasks
@@ -109,17 +109,76 @@ gulp.task('hugo:build', shell.task([
   'hugo server -D'])
 );
 
+gulp.task('hugo:all', shell.task([
+  'hugo'])
+);
+
 // =================================================================
 // dev tasks
 // =================================================================
 
-gulp.task('default', function() {
-  return runSeq(['css:build','js:build'],'hugo:serve');
+gulp.task('deploy', ['css:build','js:build'], function() {
+  return;
+});
+
+gulp.task('css:build', ['css:build:screen', 'css:build:print'], function() {
+  return;
+});
+
+gulp.task('js:build', ['js:build:all','js:build:all_nosearch'], function() {
+  return;
+});
+
+// =================================================================
+// css build tasks
+// =================================================================
+
+gulp.task("css:build:screen", function() {
+  return gulp.src(SLATE_PATH+sassScreen)
+          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
+          .pipe(cleancss())
+          .pipe(prefixer({
+              browsers: ["last 2 versions"],
+              cascade: true, // prettify browser prefixes
+              remove: true // remove un-needed prefixes
+          }))
+          .pipe(concat('screen.min.css'))
+          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
 });
 
 
-gulp.task('deploy', ['css:build','js:build'], function() {
-  return;
+gulp.task("css:build:print", function() {
+  return gulp.src(SLATE_PATH+sassPrint)
+          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
+          .pipe(cleancss())
+          .pipe(prefixer({
+              browsers: ["last 2 versions"],
+              cascade: true, // prettify browser prefixes
+              remove: true // remove un-needed prefixes
+          }))
+          .pipe(concat('print.min.css'))
+          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
+});
+
+// =================================================================
+// js build tasks
+// =================================================================
+
+gulp.task("js:build:all", function(){
+  return gulp.src(jsAllsearch)
+          .pipe(concat('all.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(jsOutput))
+          // .pipe(browserSync.stream({once: true}))
+});
+
+
+gulp.task("js:build:all_nosearch", function(){
+  return gulp.src(jsNoAllsearch)
+          .pipe(concat('all_nosearch.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(jsOutput))
+          // .pipe(browserSync.stream({once: true}))
 });
 
 // =================================================================
@@ -136,8 +195,26 @@ gulp.task('image_min', function() {
     trellisQuantisation: false
   }
 
-  return gulp.src('build/media/images/**/*.{jpg,png}',{base: './'})
-    .pipe(plumber())
-    .pipe(image_min(options))
-    .pipe(gulp.dest('./'))
+  return gulp.src(imageInput)
+          .pipe(plumber())
+          .pipe(image_min(options))
+          .pipe(size())
+          .pipe(gulp.dest('./'))
+});
+
+// image min - hugo-gulp-template
+// =================================================================
+
+gulp.task('img:min', function() {
+  return gulp.src(imageInput)
+          .pipe(size())
+          .pipe(imagemin({
+            progressive: true,
+            svgoPlugins: [
+              {removeViewBox: false},
+              {cleanupIDs: false}
+            ]
+          }))
+          .pipe(size())
+          .pipe(gulp.dest(imageOutput));
 });

--- a/package.json
+++ b/package.json
@@ -15,15 +15,18 @@
   "homepage": "https://github.com/pupil-labs/pupil-docs#readme",
   "devDependencies": {
     "babel-preset-es2015": "^6.24.0",
+    "browser-sync": "^2.18.8",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^2.3.2",
     "gulp-concat": "^2.6.1",
+    "gulp-imagemin": "^3.2.0",
     "gulp-minify": "0.0.15",
     "gulp-plumber": "^1.1.0",
     "gulp-sass": "^3.1.0",
     "gulp-shell": "^0.6.3",
+    "gulp-size": "^2.1.0",
     "gulp-uglify": "^2.1.0",
     "run-sequence": "^1.2.2"
   }


### PR DESCRIPTION
- add variables paths for gulp tasks
- add img:min gulp task
- **use BrowserSync gulp task for local dev**
   - **!** rebuilding only one JS task (either js:build:all or js:build:all_nosearch ) seems to fixed the `preview` task from firing twice. 
   - **!** but the problem still persists when watching and reloading `scss` or `md`, javascript watch task also fires. 
