### PR TITLE
Gulpfile split

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,5 @@
 // load all required libraries
 const gulp = require('gulp');
-const gutil = require('gulp-util');
-
-// node filesystem
-const fs = require('fs');
 
 // plugins - site
 const sass = require('gulp-sass');
@@ -14,130 +10,46 @@ const concat = require('gulp-concat');
 const runSeq = require('run-sequence');
 const babel = require('gulp-babel');
 const uglify = require('gulp-uglify');
-const minify = require('gulp-minify');
 const shell = require('gulp-shell');
-const rename = require('gulp-rename')
-const size = require('gulp-size')
-const imagemin = require('gulp-imagemin')
-const img_resize = require('gulp-image-resize')
-const webp = require('gulp-webp')
-const replace = require('gulp-string-replace');
-const git = require('git-rev-sync');
-const htmlmin = require('gulp-htmlmin');
 
+// Require all helper gulp tasks located in scripts
+const requireDir = require('require-dir');
+requireDir('./scripts', { recurse:true });
 
-var SLATE_PATH = "./themes/docuapi/static/slate/";
+// Paths
+const SLATE_PATH = "./themes/docuapi/static/slate/";
 
-// =================================================================
-// css build tasks
-// =================================================================
+const CS_PATH = SLATE_PATH+"/stylesheets";
 
-gulp.task("css:build:screen", function() {
-  return gulp.src(SLATE_PATH+"stylesheets/screen.css.scss")
-          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
-          .pipe(cleancss())
-          .pipe(prefixer({
-              browsers: ["last 2 versions"],
-              cascade: true, // prettify browser prefixes
-              remove: true // remove un-needed prefixes
-          }))
-          .pipe(concat('screen.min.css'))
-          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
-});
+const JS_PATH = SLATE_PATH+"/javascripts";
+const ALL_SEARCH = [
+          JS_PATH+"/lib/_energize.js",
+          JS_PATH+"lib/_jquery.js",
+          JS_PATH+"/lib/_lunr.js",
+          JS_PATH+"/lib/_jquery.highlight.js",
+          JS_PATH+"/lib/_jquery_ui.js",
+          JS_PATH+"/lib/_jquery.tocify.js",
+          JS_PATH+"/lib/_imagesloaded.min.js",
+          JS_PATH+"/lib/_lazysizes.js",
+          JS_PATH+"/lib/_modernizr-webp.js",
+          JS_PATH+"/app/_lang.js",
+          JS_PATH+"/app/_search.js",
+          JS_PATH+"/app/_toc.js",
+          JS_PATH+"/app/_modernizr-webp_poster.js",
+          JS_PATH+"/app/_custom.js"];
 
-
-gulp.task("css:build:print", function() {
-  return gulp.src(SLATE_PATH+"stylesheets/print.css.scss")
-          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
-          .pipe(cleancss())
-          .pipe(prefixer({
-              browsers: ["last 2 versions"],
-              cascade: true, // prettify browser prefixes
-              remove: true // remove un-needed prefixes
-          }))
-          .pipe(concat('print.min.css'))
-          .pipe(gulp.dest(SLATE_PATH+"stylesheets"))
-});
-
-
-gulp.task('css:build', ['css:build:screen', 'css:build:print'], function() {
-  return;
-});
-
-
-// =================================================================
-// js build tasks
-// =================================================================
-
-gulp.task("js:build:all", function(){
-  return gulp.src([SLATE_PATH+"javascripts/lib/_energize.js",
-          SLATE_PATH+"javascripts/lib/_jquery.js",
-          SLATE_PATH+"javascripts/lib/_lunr.js",
-          SLATE_PATH+"javascripts/lib/_jquery.highlight.js",
-          SLATE_PATH+"javascripts/lib/_jquery_ui.js",
-          SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
-          SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
-          SLATE_PATH+"javascripts/lib/_lazysizes.js",
-          SLATE_PATH+"javascripts/lib/_modernizr-webp.js",
-          SLATE_PATH+"javascripts/app/_lang.js",
-          SLATE_PATH+"javascripts/app/_search.js",
-          SLATE_PATH+"javascripts/app/_toc.js",
-          SLATE_PATH+"javascripts/app/_modernizr-webp_poster.js",
-          SLATE_PATH+"javascripts/app/_custom.js"])
-          .pipe(concat('all.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-gulp.task("js:build:plyr", function(){
-  return gulp.src([
-          SLATE_PATH+"javascripts/lib/_plyr.js",
-          SLATE_PATH+"javascripts/app/_plyrcontrols.js",
-          ])
-          .pipe(concat('plyr.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-gulp.task("js:build:sw", function(){
-  return gulp.src([
-          SLATE_PATH+"javascripts/app/_pupil_sw.js",
-          ])
-          .pipe(concat('pupil_sw.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest('./content'))
-});
-
-
-gulp.task("js:build:yt", function(){
-  return gulp.src(SLATE_PATH+"javascripts/app/_youtube-lazyload.js")
-          .pipe(concat('yt-lazyload.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-gulp.task("js:build:all_nosearch", function(){
-  return gulp.src([SLATE_PATH+"javascripts/lib/_energize.js",
-          SLATE_PATH+"javascripts/lib/_jquery.js",
-          SLATE_PATH+"javascripts/lib/_jquery_ui.js",
-          SLATE_PATH+"javascripts/lib/_jquery.tocify.js",
-          SLATE_PATH+"javascripts/lib/_imagesloaded.min.js",
-          SLATE_PATH+"javascripts/lib/_lazysizes.js",
-          SLATE_PATH+"javascripts/lib/_modernizr-webp.js",
-          SLATE_PATH+"javascripts/app/_lang.js",
-          SLATE_PATH+"javascripts/app/_toc.js",
-          SLATE_PATH+"javascripts/app/_modernizr-webp_poster.js",
-          SLATE_PATH+"javascripts/app/_custom.js"])
-          .pipe(concat('all_nosearch.min.js'))
-          .pipe(uglify())
-          .pipe(gulp.dest(SLATE_PATH+"javascripts"))
-});
-
-gulp.task('js:build', ['js:build:all','js:build:all_nosearch', 'js:build:plyr', 'js:build:yt', 'js:build:sw'], function() {
-
-  return;
-});
-
+const ALL_NOSEARCH = [
+          JS_PATH+"/lib/_energize.js",
+          JS_PATH+"/lib/_jquery.js",
+          JS_PATH+"/lib/_jquery_ui.js",
+          JS_PATH+"/lib/_jquery.tocify.js",
+          JS_PATH+"/lib/_imagesloaded.min.js",
+          JS_PATH+"/lib/_lazysizes.js",
+          JS_PATH+"/lib/_modernizr-webp.js",
+          JS_PATH+"/app/_lang.js",
+          JS_PATH+"/app/_toc.js",
+          JS_PATH+"/app/_modernizr-webp_poster.js",
+          JS_PATH+"/app/_custom.js"];
 
 // =================================================================
 // hugo tasks
@@ -167,106 +79,92 @@ gulp.task('public', function(cb) {
   return runSeq(['css:build','js:build'],'hugo:disk');
 });
 
-
 gulp.task('deploy', ['css:build','js:build'], function() {
   return;
 });
 
 // =================================================================
-// image min tasks - used by travis to create lq preview images
-//                   for lazy loading
+// js and css master build tasks
 // =================================================================
 
-var imgInput = './content/images/**/*.{jpg,jpeg,png}';
-var vidInput =  './content/videos/**/*.jpg';
-var imgOutput = './content/images/';
-var vidOutput = './content/videos/';
-
-gulp.task('img:minify', function() {
-  return gulp.src(imgInput)
-    .pipe(plumber())
-    .pipe(size())
-    .pipe(imagemin())
-    .pipe(size())
-    .pipe(gulp.dest(imgOutput))
-});
-
-gulp.task('img:make', function() {
-  return runSeq('img:minify', 'img:make:previews');
-});
-
-gulp.task('img:make:previews', function() {
-  return gulp.src(imgInput)
-    .pipe(plumber())
-    .pipe(size())
-    .pipe(img_resize({
-      width : 20,
-      height : 20,
-      crop : false,
-      upscale : false
-    }))
-    .pipe(rename( function(path) {
-      // be warned - no `.` in image file names!
-      var regexp = /(\.[a-zA-Z\d]+)/;
-      // regex match the branch or tag name group e.g. .master or .v093
-      // prepend _preview so final file name is
-      // final file name = some-file-name_preview.master
-      path.basename = path.basename.replace(regexp,"_preview"+"$1");
-    }))
-    .pipe(size())
-    .pipe(gulp.dest(imgOutput))
-});
-
-gulp.task('webp:make', ['webp:make:img','webp:make:vid'], function() {
+gulp.task('css:build', ['css:build:screen', 'css:build:print'], function() {
   return;
 });
 
-gulp.task('webp:make:img', function() {
-  return gulp.src(imgInput)
-    .pipe(plumber())
-    .pipe(size())
-    .pipe(webp({
-      quality : 80
-    }))
-    .pipe(size())
-    .pipe(gulp.dest(imgOutput))
-});
-
-
-// =================================================================
-// Service worker task - append git hash for cache update
-// =================================================================
-
-var gitshort = git.short()
-
-gulp.task('sw:rev', function() {
-  return gulp.src(SLATE_PATH+"javascripts/app/_pupil_sw.js")
-    .pipe(replace(/#v@hash@|\b[0-9a-f]{7}/g, gitshort))
-    .pipe(gulp.dest(SLATE_PATH+"javascripts/app"))
-});
-
-gulp.task('webp:make:vid', function() {
-  return gulp.src(vidInput)
-    .pipe(plumber())
-    .pipe(size())
-    .pipe(webp({
-      quality : 80
-    }))
-    .pipe(size())
-    .pipe(gulp.dest(vidOutput))
+gulp.task('js:build', ['js:build:all','js:build:all_nosearch', 'js:build:plyr', 'js:build:yt', 'js:build:sw'], function() {
+  return;
 });
 
 // =================================================================
-// htmlmin
+// css build tasks
 // =================================================================
 
-gulp.task('htmlmin', function() {
-  return gulp.src('./public/**/*.html')
-    .pipe(size())
-    .pipe(htmlmin({
-      collapseWhitespace: true,
-      removeComments: true
-    }))
-    .pipe(size())
-    .pipe(gulp.dest('./public'));
+gulp.task("css:build:screen", function() {
+  return gulp.src(CS_PATH+"/screen.css.scss")
+          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
+          .pipe(cleancss())
+          .pipe(prefixer({
+              browsers: ["last 2 versions"],
+              cascade: true, // prettify browser prefixes
+              remove: true // remove un-needed prefixes
+          }))
+          .pipe(concat('screen.min.css'))
+          .pipe(gulp.dest(CS_PATH))
+});
+
+
+gulp.task("css:build:print", function() {
+  return gulp.src(CS_PATH+"/print.css.scss")
+          .pipe(sass({outputStyle: 'compressed'}).on('error',sass.logError))
+          .pipe(cleancss())
+          .pipe(prefixer({
+              browsers: ["last 2 versions"],
+              cascade: true, // prettify browser prefixes
+              remove: true // remove un-needed prefixes
+          }))
+          .pipe(concat('print.min.css'))
+          .pipe(gulp.dest(CS_PATH))
+});
+
+// =================================================================
+// js build tasks
+// =================================================================
+
+gulp.task("js:build:all", function(){
+  return gulp.src(ALL_SEARCH)
+          .pipe(concat('all.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(JS_PATH))
+});
+
+gulp.task("js:build:plyr", function(){
+  return gulp.src([
+          JS_PATH+"/lib/_plyr.js",
+          JS_PATH+"/app/_plyrcontrols.js"
+          ])
+          .pipe(concat('plyr.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(JS_PATH))
+});
+
+gulp.task("js:build:sw", function(){
+  return gulp.src(JS_PATH+"/app/_pupil_sw.js")
+          .pipe(concat('pupil_sw.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest('./content'))
+});
+
+
+gulp.task("js:build:yt", function(){
+  return gulp.src(JS_PATH+"/app/_youtube-lazyload.js")
+          .pipe(concat('yt-lazyload.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(JS_PATH))
+});
+
+gulp.task("js:build:all_nosearch", function(){
+  return gulp.src(ALL_NOSEARCH)
+          .pipe(concat('all_nosearch.min.js'))
+          .pipe(uglify())
+          .pipe(gulp.dest(JS_PATH))
 });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-string-replace": "^0.4.0",
     "gulp-uglify": "^2.1.0",
     "gulp-webp": "^2.3.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^1.2.2"
   }
 }

--- a/scripts/gulphelper.js
+++ b/scripts/gulphelper.js
@@ -1,0 +1,126 @@
+// load all required libraries
+const gulp = require('gulp');
+const gutil = require('gulp-util');
+
+// node filesystem
+const fs = require('fs');
+
+// plugins - site
+const sass = require('gulp-sass');
+const prefixer = require('gulp-autoprefixer');
+const plumber = require('gulp-plumber');
+const cleancss = require('gulp-clean-css');
+const concat = require('gulp-concat');
+const runSeq = require('run-sequence');
+const babel = require('gulp-babel');
+const uglify = require('gulp-uglify');
+const minify = require('gulp-minify');
+const shell = require('gulp-shell');
+const rename = require('gulp-rename')
+const size = require('gulp-size')
+const imagemin = require('gulp-imagemin')
+const img_resize = require('gulp-image-resize')
+const webp = require('gulp-webp')
+const replace = require('gulp-string-replace');
+const git = require('git-rev-sync');
+const htmlmin = require('gulp-htmlmin');
+
+var SLATE_PATH = "./themes/docuapi/static/slate/";
+
+// =================================================================
+// image min tasks - used by travis to create lq preview images
+//                   for lazy loading
+// =================================================================
+
+var imgInput = './content/images/**/*.{jpg,jpeg,png}';
+var vidInput =  './content/videos/**/*.jpg';
+var imgOutput = './content/images/';
+var vidOutput = './content/videos/';
+
+gulp.task('img:minify', function() {
+  return gulp.src(imgInput)
+    .pipe(plumber())
+    .pipe(size())
+    .pipe(imagemin())
+    .pipe(size())
+    .pipe(gulp.dest(imgOutput))
+});
+
+gulp.task('img:make', function() {
+  return runSeq('img:minify', 'img:make:previews');
+});
+
+gulp.task('img:make:previews', function() {
+  return gulp.src(imgInput)
+    .pipe(plumber())
+    .pipe(size())
+    .pipe(img_resize({
+      width : 20,
+      height : 20,
+      crop : false,
+      upscale : false
+    }))
+    .pipe(rename( function(path) {
+      // be warned - no `.` in image file names!
+      var regexp = /(\.[a-zA-Z\d]+)/;
+      // regex match the branch or tag name group e.g. .master or .v093
+      // prepend _preview so final file name is
+      // final file name = some-file-name_preview.master
+      path.basename = path.basename.replace(regexp,"_preview"+"$1");
+    }))
+    .pipe(size())
+    .pipe(gulp.dest(imgOutput))
+});
+
+gulp.task('webp:make', ['webp:make:img','webp:make:vid'], function() {
+  return;
+});
+
+gulp.task('webp:make:img', function() {
+  return gulp.src(imgInput)
+    .pipe(plumber())
+    .pipe(size())
+    .pipe(webp({
+      quality : 80
+    }))
+    .pipe(size())
+    .pipe(gulp.dest(imgOutput))
+});
+
+gulp.task('webp:make:vid', function() {
+  return gulp.src(vidInput)
+    .pipe(plumber())
+    .pipe(size())
+    .pipe(webp({
+      quality : 80
+    }))
+    .pipe(size())
+    .pipe(gulp.dest(vidOutput))
+});
+
+// =================================================================
+// Service worker task - append git hash for cache update
+// =================================================================
+
+var gitshort = git.short()
+
+gulp.task('sw:rev', function() {
+  return gulp.src(SLATE_PATH+"javascripts/app/_pupil_sw.js")
+    .pipe(replace(/#v@hash@|\b[0-9a-f]{7}/g, gitshort))
+    .pipe(gulp.dest(SLATE_PATH+"javascripts/app"))
+});
+
+// =================================================================
+// htmlmin
+// =================================================================
+
+gulp.task('htmlmin', function() {
+  return gulp.src('./public/**/*.html')
+    .pipe(size())
+    .pipe(htmlmin({
+      collapseWhitespace: true,
+      removeComments: true
+    }))
+    .pipe(size())
+    .pipe(gulp.dest('./public'));
+});


### PR DESCRIPTION
Updated the master gulpfile and added `[require-dir](https://www.npmjs.com/package/require-dir)` node package to call other gulp helper files.

Split other gulp tasks to scripts folder. All tasks from this can be called from the top level.